### PR TITLE
Update matcher endpoint for SOAP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ app = HttpSim.build_app do
     [201, {'X-CUSTOM-HEADER' => '123'}, 'Howdy!']
   }
 
-  configure_matcher_endpoint 'POST', '/matcher', {
-    /key1/ => [202, {'X-CUSTOM-HEADER' => 'accepted'}, 'Yo!'],
-    /key2/ => [203, {'X-CUSTOM-HEADER' => 'I got this elsewhere'}, 'Yo!'],
+  configure_matcher_endpoint 'POST', '/soap', {
+    /Operation1/ => [200, {'Content-Type' => 'text/xml+soap'}, '<xml>Response1</xml>'],
+    /Operation2/ => [500, {'Content-Type' => 'text/xml+soap'}, '<xml>Response2</xml>'],
   }
 end
 

--- a/config.example.ru
+++ b/config.example.ru
@@ -9,9 +9,9 @@ app = HttpSim.build_app do
     [201, {'X-CUSTOM-HEADER' => '123'}, 'Howdy!']
   }
 
-  configure_matcher_endpoint 'POST', '/matcher', {
-    /key1/ => [202, {'X-CUSTOM-HEADER' => 'accepted'}, 'Yo!'],
-    /key2/ => [203, {'X-CUSTOM-HEADER' => 'I got this elsewhere'}, 'Yo!'],
+  configure_matcher_endpoint 'POST', '/soap', {
+    /Operation1/ => [200, {'Content-Type' => 'text/xml+soap'}, '<xml>Response1</xml>'],
+    /Operation2/ => [500, {'Content-Type' => 'text/xml+soap'}, '<xml>Response2</xml>'],
   }
 end
 

--- a/lib/http_sim/built_app.rb
+++ b/lib/http_sim/built_app.rb
@@ -127,7 +127,7 @@ module HttpSim
       @response_body = case request.env['CONTENT_TYPE']
       when 'application/json' then
         JSON.parse(request.body.read)
-      when 'application/xml' then
+      when 'text/xml' then
         Nokogiri::XML(request.body.read)
       when 'application/x-www-form-urlencoded' then
         params


### PR DESCRIPTION
- Add content-type 'text/xml' to matcher sample
- Change 'application/xml' content handling to 'text/xml'